### PR TITLE
Hacking a workaround in packer to use a default VNC value of 5900 (wh…

### DIFF
--- a/builder/xenserver/common/step_get_vnc_port.go
+++ b/builder/xenserver/common/step_get_vnc_port.go
@@ -20,7 +20,9 @@ func (self *StepGetVNCPort) Run(state multistep.StateBag) multistep.StepAction {
 	remote_vncport, err := ExecuteHostSSHCmd(state, cmd)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get VNC port (is the VM running?): %s", err.Error()))
-		return multistep.ActionHalt
+		ui.Error(fmt.Sprintf("XS7.5/7.6 no longer support xenstore-read: Try to use 5900.  See https://bugs.xenserver.org/browse/XSO-906"))
+		remote_vncport = "5900"
+		//return multistep.ActionHalt
 	}
 
 	remote_port, err := strconv.ParseUint(remote_vncport, 10, 16)


### PR DESCRIPTION
…ich seems to be all the cases) in case we cannot read that from xenstore-read command.  XS7.5 and XS7.6 has stopped supporting it