### PR TITLE
port over support for configuring vcpu numbers in xva builder

### DIFF
--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -20,11 +20,11 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	SourcePath     	string `mapstructure:"source_path"`
-	SourceTemplate 	string `mapstructure:"source_template"`
-	VCPUsMax   		uint   `mapstructure:"vcpus_max"`
-	VCPUsAtStartup  uint   `mapstructure:"vcpus_atstartup"`
-	VMMemory       	uint   `mapstructure:"vm_memory"`
+	SourcePath		string `mapstructure:"source_path"`
+	SourceTemplate	string `mapstructure:"source_template"`
+	VCPUsMax		uint   `mapstructure:"vcpus_max"`
+	VCPUsAtStartup	uint   `mapstructure:"vcpus_atstartup"`
+	VMMemory		uint   `mapstructure:"vm_memory"`
 
 	PlatformArgs map[string]string `mapstructure:"platform_args"`
 
@@ -70,7 +70,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	if self.config.VCPUsAtStartup > self.config.VCPUsMax {
 		self.config.VCPUsAtStartup = self.config.VCPUsMax
 	}
-	
+
 	if self.config.VMMemory == 0 {
 		self.config.VMMemory = 1024
 	}

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -20,9 +20,11 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	SourcePath     string `mapstructure:"source_path"`
-	SourceTemplate string `mapstructure:"source_template"`
-	VMMemory       uint   `mapstructure:"vm_memory"`
+	SourcePath     	string `mapstructure:"source_path"`
+	SourceTemplate 	string `mapstructure:"source_template"`
+	VCPUsMax   		uint   `mapstructure:"vcpus_max"`
+	VCPUsAtStartup  uint   `mapstructure:"vcpus_atstartup"`
+	VMMemory       	uint   `mapstructure:"vm_memory"`
 
 	PlatformArgs map[string]string `mapstructure:"platform_args"`
 
@@ -57,7 +59,18 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	errs = packer.MultiErrorAppend(errs, self.config.SSHConfig.Prepare(&self.config.ctx)...)
 
 	// Set default values
+	if self.config.VCPUsMax == 0 {
+		self.config.VCPUsMax = 1
+	}
 
+	if self.config.VCPUsAtStartup == 0 {
+		self.config.VCPUsAtStartup = 1
+	}
+
+	if self.config.VCPUsAtStartup > self.config.VCPUsMax {
+		self.config.VCPUsAtStartup = self.config.VCPUsMax
+	}
+	
 	if self.config.VMMemory == 0 {
 		self.config.VMMemory = 1024
 	}

--- a/builder/xenserver/xva/step_import_instance.go
+++ b/builder/xenserver/xva/step_import_instance.go
@@ -68,6 +68,18 @@ func (self *stepImportInstance) Run(state multistep.StateBag) multistep.StepActi
 	}
 	state.Put("instance_uuid", instanceId)
 
+	err = instance.SetVCPUsMax(config.VCPUsMax)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs Max=%d: %s", config.VCPUsMax, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = instance.SetVCPUsAtStartup(config.VCPUsAtStartup)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs At Startup=%d: %s", config.VCPUsAtStartup, err.Error()))
+		return multistep.ActionHalt
+	}
+
 	self.instance, err = client.GetVMByUuid(instanceId)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get VM from UUID '%s': %s", instanceId, err.Error()))


### PR DESCRIPTION
Change ported from base repo:
https://github.com/xenserver/packer-plugin-citrixhypervisor/commit/c7ac4898ed84c1f61f64e602a2306765b6811227